### PR TITLE
Consistently Apply Nightwalker Style to Download/Upload Pages

### DIFF
--- a/private/download.html
+++ b/private/download.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8" />
     <title>Add Torrent Links</title>
+    <link rel="stylesheet" href="css/nightwalker.css?v=${CACHEID}" type="text/css" />
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css" />
     <link rel="stylesheet" href="css/Window.css?v=${CACHEID}" type="text/css" />
     <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>

--- a/private/download.html
+++ b/private/download.html
@@ -4,8 +4,8 @@
 <head>
     <meta charset="UTF-8" />
     <title>Add Torrent Links</title>
-    <link rel="stylesheet" href="css/nightwalker.css?v=${CACHEID}" type="text/css" />
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css" />
+    <link rel="stylesheet" href="css/nightwalker.css?v=${CACHEID}" type="text/css" />
     <link rel="stylesheet" href="css/Window.css?v=${CACHEID}" type="text/css" />
     <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
     <script src="scripts/lib/MooTools-More-1.6.0-compat-compressed.js"></script>

--- a/private/upload.html
+++ b/private/upload.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8" />
     <title>Upload local torrent</title>
     <link rel="stylesheet" href="css/style.css?v=${CACHEID}" type="text/css" />
+    <link rel="stylesheet" href="css/nightwalker.css?v=${CACHEID}" type="text/css" />
     <link rel="stylesheet" href="css/Window.css?v=${CACHEID}" type="text/css" />
     <script src="scripts/lib/MooTools-Core-1.6.0-compat-compressed.js"></script>
     <script src="scripts/download.js?v=${CACHEID}"></script>


### PR DESCRIPTION
@CallMeBruce, here are a couple more small cosmetic changes.

For some reason, the `nightwalker.css` style was not being applied to the download and upload pages. I believe it has to do with the way the pages render in the `client.js` or `mocha-init.js` scripts, though I don't know enough about how those work to know why.

By adding `nightwalker.css` to the pages _after_ the `style.css` is applied, the download/upload pages now follow the same look as the `preferences.html` page (which inherits both styles from the `index.html`, I believe)

<details>
  <summary>download.html before/after</summary>
  <img src="https://github.com/user-attachments/assets/93bb696b-b2a5-43ec-b133-30cb06d8bc19" />
  <img src="https://github.com/user-attachments/assets/a6e07767-5308-4a90-924d-d1853a3e5669" />
</details>

<details>
  <summary>upload.html before/after</summary>
  <img src="https://github.com/user-attachments/assets/9eb02503-61de-40e5-88c3-91dfadf6368b" />
  <img src="https://github.com/user-attachments/assets/d1bd2ebb-e43b-4663-946a-4f9be863ff23" />
</details>