### PR TITLE
[Firefox-Fix] Not breaking lines when adding new torrent using url

### DIFF
--- a/private/css/nightwalker.css
+++ b/private/css/nightwalker.css
@@ -369,6 +369,9 @@ textarea {
   background: var(--color-Grey) !important;
   color: var(--color-White) !important;
   border: 0px;
+}
+
+textarea:not(#urls) {
   white-space: nowrap;
 }
 

--- a/private/css/nightwalker.css
+++ b/private/css/nightwalker.css
@@ -369,10 +369,11 @@ textarea {
   background: var(--color-Grey) !important;
   color: var(--color-White) !important;
   border: 0px;
+  white-space: nowrap;
 }
 
-textarea:not(#urls) {
-  white-space: nowrap;
+textarea#urls {
+  white-space: pre;
 }
 
 input::placeholder {


### PR DESCRIPTION
So it looks like this:
![image](https://github.com/user-attachments/assets/89490e4c-b312-46a3-9b9b-23eed3f20555)

Instead of this:
![image](https://github.com/user-attachments/assets/44a570da-d59e-4cca-8d8d-1ccfc5947511)
